### PR TITLE
fix: adjust return type of clear method

### DIFF
--- a/vendor/hypercore.d.ts
+++ b/vendor/hypercore.d.ts
@@ -166,12 +166,8 @@ declare class Hypercore<
     byteLength: number
     prefetch: number
   }): Readable
-  clear(start: number, options?: { diff: boolean }): Promise<boolean>
-  clear(
-    start: number,
-    end: number,
-    options?: { diff: boolean }
-  ): Promise<boolean>
+  clear(start: number, end?: number, opts?: { diff?: boolean }): Promise<{ blocks: number } | null>
+  clear(start: number, opts?: { diff?: boolean }): Promise<{ blocks: number } | null>
   truncate(newLength: number, forkId?: number): Promise<void>
   purge(): Promise<void>
   treeHash(length?: number): Promise<Buffer>


### PR DESCRIPTION
Could theoretically implement conditional return type based on `opts`, but not strictly necessary for our usage

https://github.com/holepunchto/hypercore/blob/a60d17b9423e5bf41143cad647618803349365de/index.js#L771