### PR TITLE
feat: add defaultStorage static method to Hypercore

### DIFF
--- a/vendor/hypercore/index.d.ts
+++ b/vendor/hypercore/index.d.ts
@@ -4,6 +4,7 @@ import { type Duplex, type Readable } from 'streamx'
 import { type Duplex as NodeDuplex } from 'stream'
 import type Protomux from 'protomux'
 import type NoiseStream from '@hyperswarm/secret-stream'
+import RandomAccessFile, { RAFOptions } from '../random-access-file'
 
 interface RemoteBitfield {
   get(index: number): boolean
@@ -149,6 +150,14 @@ declare class Hypercore<
   readonly fork: number
   readonly padding: number
   static createProtocolStream(stream: boolean | Duplex | NodeDuplex | NoiseStream | ProtocolStream | ReplicationStream | Protomux, opts: CreateProtocolStreamOpts): ReplicationStream
+  static defaultStorage<S extends (name: HypercoreStorageName) => RandomAccessStorage>(storage: S): S;
+  static defaultStorage(
+    storage: string,
+    opts?: Pick<RAFOptions, "lock" | "pool" | "writable"> & {
+      poolSize?: number;
+      rmdir?: boolean;
+      unlocked?: boolean;
+  }): (name: HypercoreStorageName) => RandomAccessFile;
 
   constructor(storage: Hypercore.HypercoreStorage)
   constructor(


### PR DESCRIPTION
Follow up for https://github.com/digidem/mapeo-core-next/pull/367

Based on the implementation found in https://github.com/holepunchto/hypercore/blob/v10.31.6/index.js#L180-L204

Don't think the definition covers _all_ of the implementation details of `Hypercore.defaultStorage()`, namely the case where you pass a RandomAccessStorage _class_ (not instance). Otherwise I think it covers the cases we care about.