### PR TITLE
feat: add new types to Hypercore

### DIFF
--- a/vendor/hypercore/index.d.ts
+++ b/vendor/hypercore/index.d.ts
@@ -132,15 +132,29 @@ type CreateProtocolStreamOpts = {
   ondiscoverykey?: (id: Buffer) => Promise<any>
 }
 
+declare class Bitfield {
+  get(index: number): boolean
+  want(start: number, length: number): IterableIterator<{
+    start: number;
+    bitfield: Uint32Array
+  }>
+}
+
+declare class Core {
+  bitfield: Bitfield
+}
+
 declare class Hypercore<
   TValueEncoding extends Hypercore.ValueEncoding = 'binary',
   TKey extends Buffer | string | undefined = undefined
 > extends TypedEmitter<Hypercore.HypercoreEvents> {
   readonly writable: boolean
   readonly readable: boolean
+  readonly closed: boolean
   readonly id: null | string
   readonly key: TKey extends undefined ? null | Buffer : Buffer
   readonly peers: any[]
+  readonly sessions: unknown[]
   readonly keyPair: null | KeyPair
   readonly discoveryKey: null | Buffer
   readonly encryptionKey: null | Buffer
@@ -148,7 +162,8 @@ declare class Hypercore<
   readonly contiguousLength: number
   readonly fork: number
   readonly padding: number
-  static createProtocolStream(stream: boolean | Duplex | NodeDuplex | NoiseStream | ProtocolStream | ReplicationStream | Protomux, opts: CreateProtocolStreamOpts): ReplicationStream
+  readonly core: null | Core
+  static createProtocolStream(stream: boolean | Duplex | NodeDuplex | NoiseStream | ProtocolStream | ReplicationStream | Protomux, opts?: CreateProtocolStreamOpts): ReplicationStream
 
   constructor(storage: Hypercore.HypercoreStorage)
   constructor(
@@ -220,6 +235,7 @@ declare class Hypercore<
     end?: number
     blocks?: number[]
     linear?: boolean
+    ifAvailable?: boolean
   }): DownloadingRange
   session(options?: Hypercore.HypercoreOptions<TValueEncoding>): Hypercore
   close(): Promise<void>


### PR DESCRIPTION
This adds the following to the `Hypercore` class:

- `closed` (see [source][closed])
- `sessions` (see [source][sessions])
- `core` (see [initialization][core init] and [assignment][core set])
- `Hypercore.createProtocolStream`'s second argument is optional (see [source][createProtocolStream])
- `ifAvailable` option to `Hypercore#download` (see [source][addRange])

These are all used by `@mapeo/core`.

[closed]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/index.js#L76
[sessions]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/index.js#L79
[core init]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/index.js#L60
[core set]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/index.js#L338
[createProtocolStream]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/index.js#L144
[addRange]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/lib/replicator.js#L1029