### PR TITLE
feat: add `preload` option to Hypercore constructor

### DIFF
--- a/vendor/hypercore/index.d.ts
+++ b/vendor/hypercore/index.d.ts
@@ -105,6 +105,7 @@ declare namespace Hypercore {
     onwait?: () => {} // hook that is called if gets are waiting for download
     timeout?: number // wait at max some milliseconds (0 means no timeout)
     writable?: boolean // disable appends and truncates
+    preload?: () => PromiseLike<Partial<HypercoreOptions<TValueEncoding, TKey>>>
   }
 
   interface HypercoreGetOptions<


### PR DESCRIPTION
The Hypercore constructor takes an option, `preload`, which can be used to asynchronously set options (see [the source][0]).

I started using this option in [a pull request][1], which is why I'm adding it now.

[0]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/index.js#L282
[1]: https://github.com/digidem/multi-core-indexer/pull/44/files#diff-4698187911815c78fd70223427e57572191603565835b90f0641b240eb357fb4R25