### PR TITLE
ci: notify downstream repos on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: token
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: ${{ matrix.downstream.owner }}
           repositories: ${{ matrix.downstream.repo }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,34 @@ jobs:
           publish-mode: oidc
           build-command: |
             npm ci
+
+  # On a successful publish (optic publishes when its release PR merges into
+  # main), tell downstream repos to fast-track the bump of this package, rather
+  # than waiting for their daily Dependabot run. Receiver: digidem/comapeo-core-react-native.
+  notify-downstream:
+    needs: release
+    if: >-
+      needs.release.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        downstream:
+          - owner: digidem
+            repo: comapeo-core-react-native
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ matrix.downstream.owner }}
+          repositories: ${{ matrix.downstream.repo }}
+      - env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh api repos/${{ matrix.downstream.owner }}/${{ matrix.downstream.repo }}/dispatches \
+            -f event_type=first-party-release \
+            -f 'client_payload[package]=@digidem/types'


### PR DESCRIPTION
Adds a `notify-downstream` job that fires a `repository_dispatch` (event type `first-party-release`) to downstream repos when `@digidem/types` publishes, so they fast-track the dependency bump instead of waiting for their daily Dependabot run.

Pairs with the receiver workflow in digidem/comapeo-core-react-native#173. The downstream destinations are a matrix (`owner`/`repo`), so adding more later is a one-line change.

Requires: `RELEASE_BOT_APP_ID` + `RELEASE_BOT_PRIVATE_KEY` available to this repo, and the Releases bot installed on each downstream repo with Contents: write (needed to send the dispatch).